### PR TITLE
Upgrade Node to 10.13.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
 
 # Let fastlane set up the other dependency managers
 before_script:
-- nvm install 8.4
+- nvm install 10.13.0
 - bundle exec fastlane setup
 
 # Separate fastlane lanes so that they can be individually


### PR DESCRIPTION
We upgraded the version of Node that emission uses in https://github.com/artsy/emission/pull/1209/files. This updates the version used in the deploy environment.