### PR TITLE
Update ruby and node versions in setup script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ before_install:
 
 # Let fastlane set up the other dependency managers
 before_script:
-- nvm install 10.13.0
-- bundle exec fastlane setup
+  - nvm install 12.13.1
+  - bundle exec fastlane setup
 
 # Separate fastlane lanes so that they can be individually
 # tested one by one during development

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ addons:
 
 # Ensure that Fastlane, node and yarn are at the latest versions
 before_install:
-  - rvm install ruby-2.5.3
+  - rvm install ruby-2.6.3
   - gem install bundler
   - bundle update fastlane
   - bundle exec fastlane env


### PR DESCRIPTION
The CI build is failing possibly because of a Ruby versioning difference. This PR updates the setup script to use version 2.6.3.